### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ use, except if there is only one, then no choice is presented. If the profile ha
 `eapconfig_endpoint` field, the .eap-config is downloaded from that URL, without any authentication.
 If the profile also has an `token_endpoint` and `authorization_endpoint`, the application will start
 an OAuth Authorization Code Flow, and then download the `.eap-config` file from `eapconfig_endpoint`
-and presenting the access token as a Bearer token in an authorization header.
+and present the access token as a Bearer token in an authorization header.
 
 When the downloaded `.eap-config` file does not contain enough credentials the user must be prompted
 for username/password as these are not contained in the file itself. This happens for the
@@ -58,15 +58,15 @@ The authorization flow and parsing of the xml data must be handled by each platf
 connectivity [...]. On Android 11 and higher, the Settings Intent API enables you to ask the user to
 approve adding a saved network or Passpoint configuration."
 
-In general the app will use the following APIs for createing the WiFI configuration:
+In general the app will use the following APIs for creating the WiFI configuration:
 
 * Android >= Android 11 (API 30) use an intent with action `ACTION_WIFI_ADD_NETWORKS` (
-  avaialble only starting from API 30). Pass the `WifiNetworkSuggestion` including passpoint
+  available only starting from API 30). Pass the `WifiNetworkSuggestion` including passpoint
   configuration if available to the intent bundle.
 
 * Android == Android 10 (API 29) the Wifi Suggestion API is available, but not
-  the `ACTION_WIFI_ADD_NETWORKS` for the intent, therefor must use
-  `WifiManager.addNetworkSuggestions(wifiNetworkSuggestions)`. List must including the passpoint
+  the `ACTION_WIFI_ADD_NETWORKS` for the intent, therefore must use
+  `WifiManager.addNetworkSuggestions(wifiNetworkSuggestions)`. List must include the passpoint
   configuration. To ensure we don't duplicate networks, any previously added suggestions need to be
   removed before hand. These calls may change the networks state and the permission
   for `CHANGE_WIFI_STATE` is required if not granted.


### PR DESCRIPTION
~~You won't be able to see the changes in the JSON file online, it's a huge 1.5 MB one-liner.~~

~~To see the changes, do as follows:~~
<details>
<summary>deleted</summary>

```
$ git checkout main
$ python3 -m json.tool android/app/src/main/res/raw/default_list.json  > default_list.json.OLD
$ 
$ git checkout codespell
$ python3 -m json.tool android/app/src/main/res/raw/default_list.json  > default_list.json.NEW
$ 
$ diff default_list.json.OLD default_list.json.NEW 
16610c16610
<             "name": "Faculty of Medicine, Univeristy of Kelaniya",
---
>             "name": "Faculty of Medicine, University of Kelaniya",
45661c45661
<             "name": "Opole University of Technnology",
---
>             "name": "Opole University of Technology",
65541c65541
<             "name": "Technical Univeristy of Lodz",
---
>             "name": "Lodz University of Technology",
71363c71363
<             "name": "Univeristy of Kelaniya",
---
>             "name": "University of Kelaniya",
88603c88603
<             "name": "Wroclaw University of Enviromental and Life Sciences",
---
>             "name": "Wroclaw University of Environmental and Life Sciences",
$ 
```
</details>

~~Rationale for the changes in the JSON file:~~
* ~~University of Kelaniya: it's Unive**rsi**ty, not Unive**ris**ty~~
* ~~Opole University of Technology: it's Tech**n**ology, not Tech**nn**ology~~
* ~~Lodz University of Technology: it's Unive**rsi**ty, not Unive**ris**ty, plus the name in English is [Lodz University of Technology](https://p.lodz.pl/en) on their web site~~
* ~~Wroclaw University of Environmental and Life Sciences: it's Enviro**nm**ental, not Enviro**m**ental~~
