### PR TITLE
Filter certificates based on encoding and format, imrove User-Agent header

### DIFF
--- a/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/PlatformWifiConfigData.kt
@@ -108,7 +108,10 @@ private fun EAPIdentityProviderList.buildEnterpriseConfig(): WifiEnterpriseConfi
     val enterpriseEAP = authMethod?.eapMethod?.type?.toInt()?.convertEAPMethod() ?: Eap.NONE
     enterpriseConfig.eapMethod = enterpriseEAP
 
-    val caCertificates = authMethod?.serverSideCredential?.certData?.mapNotNull { it.value }
+    val caCertificates = authMethod?.serverSideCredential
+        ?.certData
+        ?.filter { it.isSupported() }
+        ?.mapNotNull { it.value }
     enterpriseConfig.caCertificates = getCertificates(caCertificates)
         .filter { isCA(it) }
         .toTypedArray()
@@ -230,7 +233,12 @@ private fun EAPIdentityProviderList.getServerNamesDomainDependentOnAndroidVersio
  */
 fun EAPIdentityProviderList.buildPasspointConfig(): PasspointConfiguration? {
     val eapIdentityProvider = eapIdentityProvider?.first()
-    val caCertificates = eapIdentityProvider?.authenticationMethod?.bestMethod()?.serverSideCredential?.certData?.mapNotNull { it.value }
+    val caCertificates = eapIdentityProvider?.authenticationMethod
+        ?.bestMethod()
+        ?.serverSideCredential
+        ?.certData
+        ?.filter { it.isSupported() }
+        ?.mapNotNull { it.value }
     val oids = eapIdentityProvider?.credentialApplicability?.map { it.consortiumOID?.toLong(16) }?.filterNotNull() ?: listOf()
     val fqdn: String? = eapIdentityProvider?.ID
 

--- a/android/app/src/main/java/app/eduroam/geteduroam/config/model/CertData.kt
+++ b/android/app/src/main/java/app/eduroam/geteduroam/config/model/CertData.kt
@@ -17,4 +17,6 @@ class CertData {
 
     @field:Attribute
     var encoding: String? = null
+
+    fun isSupported() = format == "X.509" && encoding == "base64" && !value.isNullOrEmpty()
 }


### PR DESCRIPTION
Addresses #135

Also includes a better User-Agent header:
<img width="748" alt="Screenshot 2025-05-06 at 8 39 25" src="https://github.com/user-attachments/assets/b284c589-3f2a-4d09-b86e-deda04bd3ada" />

